### PR TITLE
Fix one hour wait

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"flag"
@@ -9,6 +10,9 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,6 +34,18 @@ var (
 	})
 )
 
+func newServer(file, port string) *http.Server {
+	CACertPath = file
+	router := http.NewServeMux()
+	router.HandleFunc("/", serveFile)
+	router.Handle("/metrics", promhttp.Handler())
+
+	return &http.Server{
+		Addr:    			":" + port,
+		Handler: router,
+	}
+}
+
 func serveFile(w http.ResponseWriter, r *http.Request) {
 	data, err := ioutil.ReadFile(CACertPath)
 	if err != nil {
@@ -38,31 +54,27 @@ func serveFile(w http.ResponseWriter, r *http.Request) {
 	http.ServeContent(w, r, "ca.crt", time.Now(), bytes.NewReader(data))
 }
 
-func listenAndServe(file, port string) {
-	CACertPath = file
-	http.HandleFunc("/", serveFile)
-	http.Handle("/metrics", promhttp.Handler())
+func startMetricsCollector() {
+	collectMetrics()
 
-	log.Printf("Serving %s on HTTP port: %s\n", file, port)
-	log.Fatal(http.ListenAndServe(":"+port, nil))
-}
-
-func collectMetrics() {
 	ticker := time.NewTicker(time.Hour)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			expiryTimestamp, err := getCertExpiryTimestamp(CACertPath)
-			if err != nil {
-				log.Printf("Error getting certificate expiry: %v\n", err)
-				continue
-			}
-			CACertExpiryMetric.Set(float64(expiryTimestamp.Unix()))
-			log.Printf("CA certificate expiry: %s\n", expiryTimestamp)
+			collectMetrics()
 		}
 	}
+}
+
+func collectMetrics() {
+	expiryTimestamp, err := getCertExpiryTimestamp(CACertPath)
+	if err != nil {
+		log.Printf("Error getting certificate expiry: %v\n", err)
+		return
+	}
+	CACertExpiryMetric.Set(float64(expiryTimestamp.Unix()))
 }
 
 func getCertExpiryTimestamp(certFile string) (time.Time, error) {
@@ -84,9 +96,31 @@ func getCertExpiryTimestamp(certFile string) (time.Time, error) {
 	return cert.NotAfter, nil
 }
 
+func listenForShutdown(ctx context.Context, server *http.Server) {
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	<-stop
+
+	log.Printf("Shutting down")
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	err := server.Shutdown(ctx)
+	if err != nil {
+		log.Println(err, "Failed to shutdown http server")
+	}
+}
+
 func main() {
 	flag.Parse()
 	prometheus.MustRegister(CACertExpiryMetric)
-	go collectMetrics()
-	listenAndServe(*file, *port)
+
+	server := newServer(*file, *port)
+	go listenForShutdown(context.Background(), server)
+	go startMetricsCollector()
+	log.Printf("Serving %s on HTTP port: %s\n", *file, *port)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("Error starting HTTP server: %v", err)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -54,7 +54,8 @@ func TestListenAndServeFileUpdate(t *testing.T) {
 	if _, err := tmpfile.Write(content); err != nil {
 		log.Fatal(err)
 	}
-	go listenAndServe(tmpfile.Name(), "8080")
+	server := newServer(tmpfile.Name(), "8080")
+	go server.ListenAndServe()
 	waitForServerToStart()
 	// Get from server to verify we are serving the content
 	resp, err := readFromTestServer()


### PR DESCRIPTION
Collecting metrics first before executing the one hour wait loop.
Also added a signal trap for graceful shutdown